### PR TITLE
feat: add warning for missing SerpAPI key in SerpAPIProvider

### DIFF
--- a/krod/modules/research/web_search/search_provider.py
+++ b/krod/modules/research/web_search/search_provider.py
@@ -45,3 +45,6 @@ class SerpAPIProvider(SearchProvider):
 
         self.logger = logging.getLogger("krod.web_search.serpapi")
         self.api_key = api_key or os.getenv("SERPAPI_KEY")
+        if not self.api_key:
+            self.logger.warning("No SerpAPI key provided. Please set SERPAPI_KEY environment variable.")
+        self.engine = engine


### PR DESCRIPTION
- Implemented a warning log when no SerpAPI key is provided, prompting users to set the SERPAPI_KEY environment variable for proper functionality.
- Initialized the engine attribute in the SerpAPIProvider class.